### PR TITLE
Remove cloud service badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ I sit at the intersection of **AI/ML**, **cloud infrastructure**, and **data eng
 **Cloud & Data**
 
 ![AWS](https://img.shields.io/badge/AWS-FF9900?style=flat-square&logo=amazonaws&logoColor=white)
-![GCP](https://img.shields.io/badge/GCP-4285F4?style=flat-square&logo=googlecloud&logoColor=white)
-![Apache Spark](https://img.shields.io/badge/Spark-E25A1C?style=flat-square&logo=apachespark&logoColor=white)
-![Airflow](https://img.shields.io/badge/Airflow-017CEE?style=flat-square&logo=apacheairflow&logoColor=white)
+
 
 **Dev & Infra**
 


### PR DESCRIPTION
Removed GCP, Apache Spark, and Airflow badges from the README.